### PR TITLE
Use regex (instead of printf) format for the package name (in repository mode)

### DIFF
--- a/prepare_ppa_package
+++ b/prepare_ppa_package
@@ -224,10 +224,20 @@ function check_and_set_env_variables {
     #
     v_package_version=$(IFS=.; echo "${BASH_REMATCH[*]:1}")
 
+    # See limitation below.
+    #
+    if [[ $PPA_PAK_PACKAGE_NAME == */* ]]; then
+      >&2 echo "The package name regex doesn't currently support slashes!"
+      exit 1
+    fi
+
     # This will ignore arguments, if there aren't (enough) placeholder, which allows ignoring patch
     # versions, or using a fixed package name.
     #
-    v_package_name=$(perl -pe 's/$ENV{tag_regex}/$ENV{PPA_PAK_PACKAGE_NAME/' <<< "$v_latest_tag")
+    # Perl doesn't interpret the matching variables when the string is an ENV variable, so we need
+    # to work this around.
+    #
+    v_package_name=$(perl -pe 's/$ENV{tag_regex}/'"${PPA_PAK_PACKAGE_NAME}"'/' <<< "$v_latest_tag")
   else
     v_package_version=$PPA_PAK_VERSION
     v_package_name=$PPA_PAK_PACKAGE_NAME

--- a/prepare_ppa_package
+++ b/prepare_ppa_package
@@ -111,7 +111,7 @@ Don't forget that the regex is in Bash format, which doesn't support all the PCR
 
 # Mandatory
 
-export PPA_PAK_PACKAGE_NAME='ruby%i.%i'
+export PPA_PAK_PACKAGE_NAME='ruby\$1.\$2'
 export PPA_PAK_VERSION='/v(3)_(1)_([0-9]+)/'
 export PPA_PAK_COPYRIGHT=~/build/ruby/BSDL
 export PPA_PAK_LAUNCHPAD_ID='myuser'
@@ -211,7 +211,7 @@ function check_and_set_env_variables {
   local v_package_version
 
   if [[ $PPA_PAK_VERSION =~ /(.+)/ ]]; then
-    local tag_regex=^${BASH_REMATCH[1]}$
+    declare -x tag_regex=^${BASH_REMATCH[1]}$
 
     v_latest_tag=$(find_latest_tag "$tag_regex")
 
@@ -227,7 +227,7 @@ function check_and_set_env_variables {
     # This will ignore arguments, if there aren't (enough) placeholder, which allows ignoring patch
     # versions, or using a fixed package name.
     #
-    v_package_name=$(perl -e "printf '$PPA_PAK_PACKAGE_NAME', @ARGV" "${BASH_REMATCH[@]:1}")
+    v_package_name=$(perl -pe 's/$ENV{tag_regex}/$ENV{PPA_PAK_PACKAGE_NAME/' <<< "$v_latest_tag")
   else
     v_package_version=$PPA_PAK_VERSION
     v_package_name=$PPA_PAK_PACKAGE_NAME

--- a/presets/prepare_ruby_repository
+++ b/presets/prepare_ruby_repository
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Shellcheck thinks that '$1.$2' is a mistake.
+# shellcheck disable=2016
+
 set -o errexit
 
 if [[ $# -ne 1 || $1 == '-h' || $1 == '--help' ]]; then
@@ -18,8 +21,8 @@ fi
 #
 # The autotools-dev package provides the config.* files.
 
-export PPA_PAK_PACKAGE_NAME='ruby3.1'
-export PPA_PAK_VERSION='3.1.2'
+export PPA_PAK_PACKAGE_NAME='ruby$1.$2'
+export PPA_PAK_VERSION='/v(3)_(1)_([0-9]+)/'
 export PPA_PAK_COPYRIGHT='gpl2'
 export PPA_PAK_DESCRIPTION='Interpreter of object-oriented scripting language Ruby'
 export PPA_PAK_HOMEPAGE='https://www.ruby-lang.org/'
@@ -29,4 +32,4 @@ export PPA_PAK_SECTION='interpreters'
 export PPA_PAK_BUILD_DEPS='autotools-dev,ruby,autoconf,automake,bison,ca-certificates,curl,libc6-dev,libffi-dev,libgdbm-dev,libncurses5-dev,libsqlite3-dev,libtool,libyaml-dev,make,openssl,patch,pkg-config,sqlite3,zlib1g,zlib1g-dev,libreadline-dev,libssl-dev,libgmp-dev'
 export PPA_PAK_DH_OVERRIDES=$'execute_before_dh_auto_configure:\n\t./autogen.sh\n\tcp /usr/share/misc/config.* tool/'
 
-"$(dirname "$0")"/../prepare_ppa_package -c "$1"
+"$(dirname "$0")"/../prepare_ppa_package -u "$1"


### PR DESCRIPTION
Also fixed the `prepare_ruby_repository` metadata (and updated their format).