### PR TITLE
Drop support for Ubuntu versions prior to Jammy (bionic, focal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ export PPA_PAK_EMAIL='myuser@gmail.com'
 export PPA_PAK_COPYRIGHT='gpl2'
 export PPA_PAK_DESCRIPTION='Interpreter of object-oriented scripting language Ruby'
 export PPA_PAK_HOMEPAGE='https://www.ruby-lang.org/'
-export PPA_PAK_DISTROS='focal,jammy'
+export PPA_PAK_DISTROS='jammy'
 export PPA_PAK_SECTION='interpreters'
 export PPA_PAK_BUILD_DEPS='autoconf,automake,bison,ca-certificates,curl,libc6-dev,libffi-dev,libgdbm-dev,libncurses5-dev,libsqlite3-dev,libtool,libyaml-dev,make,openssl,patch,pkg-config,sqlite3,zlib1g,zlib1g-dev,libreadline-dev,libssl-dev,libgmp-dev'
 

--- a/prepare_ppa_package
+++ b/prepare_ppa_package
@@ -25,7 +25,7 @@ export c_changelog_description="Upstream version"
 
 declare -A c_required_packages=([dh_make]=dh-make [debuild]=devscripts [cowbuilder]=cowbuilder)
 
-declare -A c_debhelper_distro_versions=([kinetic]=13 [jammy]=13 [focal]=12 [bionic]=11)
+declare -A c_debhelper_distro_versions=([kinetic]=13 [jammy]=13)
 c_default_debian_version=ppa1
 c_package_ppa_version=1
 # Requires a subdirectory named <distroname> for each distro build environment.
@@ -124,7 +124,7 @@ export PPA_PAK_HOMEPAGE='https://www.ruby-lang.org/'
 export PPA_PAK_DEBIAN_VERSION=mydeb1
 export PPA_PAK_BUILD_DEPS='autoconf,automake,bison,ca-certificates' # incomplete
 export PPA_PAK_DEPS='libgmp-dev'
-export PPA_PAK_DISTROS='bionic,focal'
+export PPA_PAK_DISTROS='jammy'
 export PPA_PAK_LONG_DESCRIPTION=\$'Ruby is the\ninterpreted scripting language\nfor quick and easy'
 export PPA_PAK_SECTION='interpreters'
 export PPA_PAK_VCS_GIT='https://github.com/ruby/ruby.git'
@@ -423,8 +423,7 @@ function build_source_packages {
   #
   # `--no-tgz-check`:  don't search for the original when a debian version is present
   # `--no-lintian`:    save time; for testing purposes
-  # `-d`:              skip the dependency checks, due to `debhelper` on xenial (debuild assumes
-  #                    that the build happens on the same machine)
+  # `-d`:              skip the dependency checks (debuild assumes that the build happens on the same machine)
   # `-S`:              build a source package; `--build=source` is equivalent, but oddly, doesn't find
   #                    the changes file during build
   # `-Zgzip`:          fast compression; for testing purposes.


### PR DESCRIPTION
## Summary

- Remove `bionic` (18.04) and `focal` (20.04) from `c_debhelper_distro_versions`
- Update example `PPA_PAK_DISTROS` in script help and README to reflect jammy-only defaults
- Clean up outdated xenial reference in `-d` flag comment

Both bionic and focal are end-of-life or near-EOL; jammy (22.04 LTS) is the oldest supported release going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)